### PR TITLE
Change type of tokenizedCVC from String to TokenizedCVC

### DIFF
--- a/PaygentTokenSDK/Responses.swift
+++ b/PaygentTokenSDK/Responses.swift
@@ -39,7 +39,7 @@ public struct TokenizedCard: Codable {
 
 public struct PaygentCVCTokenResponse: Codable {
     public let result: String
-    public let tokenizedCVC: String
+    public let tokenizedCVC: TokenizedCVC
     
     enum CodingKeys: String, CodingKey {
         case result


### PR DESCRIPTION
When using PaygentCVCTokenRequest, In spite of the response is success(code:0000),
it's handled as failure.
 
response data:
`{\"result\":\"0000\",\"tokenizedCardObject\":{\"token\":\"tok_dXGXA5s9FaHc0OIx2H7SuNtCwL\",\"valid_until\":\"20180320200251\"}}`

Because the type of Response(PaygentCVCTokenResponse) is different from response 